### PR TITLE
Added configuration to modify the others ACL entry

### DIFF
--- a/lib/capistrano/tasks/file-permissions.rake
+++ b/lib/capistrano/tasks/file-permissions.rake
@@ -40,6 +40,10 @@ namespace :deploy do
           entries.push(*acl_entries(fetch(:file_permissions_groups), 'g'))
         end
 
+        if fetch(:file_permissions_modify_other)
+          entries.push(*acl_entries([''], 'o'))
+        end
+
         entries = entries.map { |e| "-m #{e}" }.join(' ')
 
         execute :setfacl, "-R", entries, *paths
@@ -94,6 +98,7 @@ end
 namespace :load do
   task :defaults do
     set :file_permissions_roles, :all
+    set :file_permissions_modify_other, false
     set :file_permissions_paths, []
     set :file_permissions_users, []
     set :file_permissions_groups, []


### PR DESCRIPTION
In the seldom cases when you need to modify permissions of someone other than a specific user or a group, setting **file_permissions_modify_other** to true adds this ability to modify setfacl as needed.